### PR TITLE
gfx: Properly set graphics thread delay

### DIFF
--- a/src/gfx.c
+++ b/src/gfx.c
@@ -157,27 +157,28 @@ static int draw_webp(uint8_t *buf, size_t len) {
   }
 
   int lastTimestamp = 0;
+  int delay = 0;
   TickType_t drawStartTick = xTaskGetTickCount();
-  // Set delay to > 0 for initial delay; else FreeRTOS assertion fails
-  int delay = 1;
 
   // Draw each frame, and sleep for the delay
   for (int j = 0; j < animation.frame_count; j++) {
     uint8_t *pix;
     int timestamp;
     WebPAnimDecoderGetNext(decoder, &pix, &timestamp);
-    xTaskDelayUntil(&drawStartTick, pdMS_TO_TICKS(delay));
+    if (delay > 0)
+      xTaskDelayUntil(&drawStartTick, pdMS_TO_TICKS(delay));
     drawStartTick = xTaskGetTickCount();
     display_draw(pix, animation.canvas_width, animation.canvas_height, 4, 0, 1,
                  2);
     delay = timestamp - lastTimestamp;
     lastTimestamp = timestamp;
   }
-  xTaskDelayUntil(&drawStartTick, pdMS_TO_TICKS(delay));
+  if (delay > 0)
+    xTaskDelayUntil(&drawStartTick, pdMS_TO_TICKS(delay));
 
   // In case of a single frame, sleep for 1s
   if (animation.frame_count == 1) {
-    vTaskDelay(pdMS_TO_TICKS(1000));
+    xTaskDelayUntil(&drawStartTick, pdMS_TO_TICKS(1000));
   }
 
   WebPAnimDecoderDelete(decoder);


### PR DESCRIPTION
This PR properly sets the delay for the graphics drawing thread (task).

The original implementation is incorrect because when calculating the number of ticks to sleep the graphics task for, the task begins sleeping after some ticks which should be included in the calculated number have already passed.

For example, let `t` be the time in ms at which the frame starts to get rendered and `d` be a delay (in our case, the frame duration). We expect that the next frame begin rendering at `t'=t+d`. However, consider processing time `p`. The current implementation begins rendering the next frame at `t'=t+p+d`, since using `vTaskDelay` delays the current task *relative* to when that function is called (at time `t+p`) (see [FreeRTOS API documentation](https://www.freertos.org/a00127.html)). This time misalignment compounds for each frame, since the computation delay occurs for each frame. So if the animation has 1000 frames and extraneous computation time takes 2 ticks (for the TidByt's hardware configuration, 1 tick = 1ms), then the animation is played for 2 seconds longer than it should, an order of magnitude (!!!) in CPU time! If the computation time takes even longer (say, 4 or 5 ticks), this results in many seconds worth of time misalignment.

This fix uses `xTaskDelayUntil`, which is the recommended API call to schedule task delays that end on an absolute time. This allows us to exploit the RTOS' scheduler so that the next frame begins drawing at `t'=t+d`.